### PR TITLE
Fix a bug with fallback files

### DIFF
--- a/src/components/ProjectMap/ViewController.tsx
+++ b/src/components/ProjectMap/ViewController.tsx
@@ -82,7 +82,7 @@ export default function ViewController() {
   const [classificationFilterMode, setClassificationFilterMode] = useState<ClassificationFilterMode>("All");
   const { data: getProjectsResponse } = useSWR(
       [getProjects], 
-      () => fetchWithBackup(getProjects),
+      () => fetchWithBackup('getProjects', getProjects),
       { suspense: true }
   );
 
@@ -173,7 +173,7 @@ export default function ViewController() {
   const { data: projectOverviewResponse } = useSWR(
     // having null as the key makes SWR always instantly return { data: undefined, error: undefined, isLoading: false }
     state.project != "" ? [validProjectsData[state.project], getProjectOverview] : null, 
-    () => fetchWithBackup(getProjectOverview, validProjectsData[state.project].projectName),
+    () => fetchWithBackup('getProjectOverview', getProjectOverview, validProjectsData[state.project].projectName),
     { suspense: true }
   ) 
 

--- a/src/scripts/createBackups.ts
+++ b/src/scripts/createBackups.ts
@@ -7,13 +7,14 @@ import {
 } from '../utils/adstash';
 
 async function fetchBackup<T extends unknown[], K>(
+  functionKey: string,
   fetcher: (...args: T) => Promise<K>,
   args: T
 ): Promise<void> {
   const data = await fetcher(...args);
   const backupData = { data, date: new Date().toISOString() };
   
-  const fileName = getBackupPath(fetcher, args);
+  const fileName = getBackupPath(functionKey, args);
   const backupFilePath = path.join(BACKUP_DIRECTORY, fileName);
 
   fs.mkdirSync(path.dirname(backupFilePath), { recursive: true });
@@ -28,18 +29,18 @@ async function buildBackupMap(): Promise<(() => Promise<void>)[]> {
   const institutions = await getInstitutions();
 
   return [
-    () => fetchBackup(getLatestOSPoolOverview, []),
-    () => fetchBackup(getDateOfLatestData, []),
-    () => fetchBackup(getProjects, []),
-    () => fetchBackup(getInstitutions, []),
-    () => fetchBackup(getInstitutionsOverview, []),
+    () => fetchBackup("getLatestOSPoolOverview", getLatestOSPoolOverview, []),
+    () => fetchBackup("getDateOfLatestData", getDateOfLatestData, []),
+    () => fetchBackup("getProjects", getProjects, []),
+    () => fetchBackup("getInstitutions", getInstitutions, []),
+    () => fetchBackup("getInstitutionsOverview", getInstitutionsOverview, []),
     ...Object.values(projects).map(p => {
       const name = p.projectName ?? "";
-      return () => fetchBackup(getProjectOverview, [name]);
+      return () => fetchBackup("getProjectOverview", getProjectOverview, [name]);
     }),
     ...Object.values(institutions).map(i => {
       const name = i.institutionName ?? "";
-      return () => fetchBackup(getInstitutionOverview, [name]);
+      return () => fetchBackup("getInstitutionOverview", getInstitutionOverview, [name]);
     }),
   ];
 }

--- a/src/utils/fetchWithBackup.ts
+++ b/src/utils/fetchWithBackup.ts
@@ -1,6 +1,7 @@
 import { getBackupPath, BACKUP_URL_PATH } from './helpers';
 
 export default async function fetchWithBackup<T extends unknown[], K>(
+  functionKey: string,
   fetcher: (...args: T) => Promise<K>,
   ...args: T
 ): Promise<{
@@ -12,7 +13,7 @@ export default async function fetchWithBackup<T extends unknown[], K>(
     const data = await fetcher(...args);
     return { data, date: new Date(), fromBackup: false };
   } catch {
-    const fileName = getBackupPath(fetcher, args);
+    const fileName = getBackupPath(functionKey, args);
     const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
     const backupUrl = `${basePath}${BACKUP_URL_PATH}/${fileName}`;
 

--- a/src/utils/fetchWithBackup.ts
+++ b/src/utils/fetchWithBackup.ts
@@ -18,7 +18,18 @@ export default async function fetchWithBackup<T extends unknown[], K>(
     const backupUrl = `${basePath}${BACKUP_URL_PATH}/${fileName}`;
 
     const response = await fetch(backupUrl);
-    if (!response.ok) throw new Error(`Backup not found: ${response.statusText}`);
+    if (!response.ok) {
+      let errorMessage = [
+        `Backup not found: ${response.statusText}`,
+        `fileName: ${fileName}`,
+        `basePath: ${basePath}`,
+        `backupUrl: ${backupUrl}`,
+        `functionKey: ${functionKey}`,
+        `fetcher: ${fetcher}`,
+        `args: ${JSON.stringify(args)}`
+      ].join('\n\t')
+      throw new Error(errorMessage);
+    }
 
     const backup = (await response.json()) as { data: K, date: string };
     return { 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -46,8 +46,8 @@ export function generateHash(string: string) {
 export const BACKUP_DIRECTORY = './public/fallbacks'; // filesystem path for script
 export const BACKUP_URL_PATH = '/fallbacks'; // HTTP path for runtime
 
-export function getBackupPath<T extends unknown[]>(fetcher: (...args: T) => unknown, args: T): string {
-  const hash = generateHash(`${fetcher.name}:${JSON.stringify(args)}`);
+export function getBackupPath(functionKey: string, args: unknown[]): string {
+  const hash = generateHash(`${functionKey}:${JSON.stringify(args)}`);
   return `${hash}.json`;
 }
 


### PR DESCRIPTION
The issue with the fallback files on the production site was that the production site automatically minifies and mangles all functions. 

We were using the function name itself as part of the key for the hash of the fallback file meaning the hash would change after build. 

This fixes that by adding a string of the same contents as the function name to act as the key for the hash instead. Strings are never mangled or minified.

Also dded extra error handling in case this happens again.